### PR TITLE
Fix some Splint warnings adding related to `nullret` rule in some functions

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -822,7 +822,8 @@ INTERNAL otrng_result otrng_client_add_forging_key(
 
 API otrng_client_profile_s *
 otrng_client_get_client_profile(otrng_client_s *client) {
-  assert(client != NULL && client->client_profile != NULL);
+  assert(client != NULL);
+  assert(client->client_profile != NULL);
 
   return client->client_profile;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -822,8 +822,7 @@ INTERNAL otrng_result otrng_client_add_forging_key(
 
 API otrng_client_profile_s *
 otrng_client_get_client_profile(otrng_client_s *client) {
-  assert(client != NULL);
-  assert(client->client_profile != NULL);
+  assert(client != NULL && client->client_profile != NULL);
 
   return client->client_profile;
 }

--- a/src/otrng.c
+++ b/src/otrng.c
@@ -556,7 +556,7 @@ tstatic otrng_result serialize_and_encode_auth_r(string_p *dst,
   return OTRNG_SUCCESS;
 }
 
-tstatic char *
+tstatic /*@null@*/ char *
 otrng_generate_session_state_string(const otrng_shared_session_state_s *state) {
   char *sss;
   size_t sss_len;
@@ -589,7 +589,7 @@ otrng_generate_session_state_string(const otrng_shared_session_state_s *state) {
   return sss;
 }
 
-static const char *get_shared_session_state(otrng_s *otr) {
+/*@null@*/ static const char *get_shared_session_state(otrng_s *otr) {
   otrng_shared_session_state_s state;
 
   if (otr->shared_session_state) {
@@ -978,7 +978,8 @@ tstatic otrng_result reply_with_non_interactive_auth_message(string_p *dst,
 }
 
 /* This is only used for tests */
-INTERNAL prekey_ensemble_s *otrng_build_prekey_ensemble(otrng_s *otr) {
+INTERNAL /*@null@*/ prekey_ensemble_s *
+otrng_build_prekey_ensemble(otrng_s *otr) {
   ecdh_keypair_s ecdh;
   dh_keypair_s dh;
   otrng_client_s *client;
@@ -1779,7 +1780,8 @@ tstatic otrng_result receive_auth_i(char **dst, const uint8_t *buffer,
   return otrng_send_message(dst, "", NULL, MSG_FLAGS_IGNORE_UNREADABLE, otr);
 }
 
-tstatic tlv_list_s *deserialize_received_tlvs(const uint8_t *src, size_t len) {
+/*@null@*/ tstatic tlv_list_s *deserialize_received_tlvs(const uint8_t *src,
+                                                         size_t len) {
   uint8_t *tlvs_start = NULL;
   size_t tlvs_len;
 
@@ -1838,7 +1840,7 @@ tstatic unsigned int extract_word(const unsigned char *bufp) {
   return use;
 }
 
-tstatic tlv_s *process_tlv(const tlv_s *tlv, otrng_s *otr) {
+/*@null@*/ tstatic tlv_s *process_tlv(const tlv_s *tlv, otrng_s *otr) {
   if (tlv->type == OTRNG_TLV_NONE || tlv->type == OTRNG_TLV_PADDING) {
     return NULL;
   }
@@ -1864,9 +1866,8 @@ tstatic tlv_s *process_tlv(const tlv_s *tlv, otrng_s *otr) {
   return otrng_process_smp_tlv(tlv, otr);
 }
 
-tstatic otrng_result process_received_tlvs(tlv_list_s **to_send,
-                                           otrng_response_s *response,
-                                           otrng_s *otr) {
+/*@null@*/ tstatic otrng_result process_received_tlvs(
+    tlv_list_s **to_send, otrng_response_s *response, otrng_s *otr) {
   const tlv_list_s *current = response->tlvs;
   while (current) {
     tlv_s *tlv = process_tlv(current->data, otr);

--- a/src/otrng.h
+++ b/src/otrng.h
@@ -108,7 +108,8 @@ API otrng_result otrng_send_non_interactive_auth(
 
 API otrng_result otrng_init(otrng_bool die);
 
-INTERNAL prekey_ensemble_s *otrng_build_prekey_ensemble(otrng_s *otr);
+INTERNAL /*@null@*/ prekey_ensemble_s *
+otrng_build_prekey_ensemble(otrng_s *otr);
 
 API int otrng_get_msg_type(const string_p msg);
 
@@ -121,7 +122,7 @@ tstatic otrng_shared_session_state_s
     tstatic
     otrng_get_shared_session_state(otrng_s *otr);
 
-tstatic char *
+tstatic /*@null@*/ char *
 otrng_generate_session_state_string(const otrng_shared_session_state_s *state);
 
 tstatic tlv_s *process_tlv(const tlv_s *tlv, otrng_s *otr);

--- a/src/prekey_manager.c
+++ b/src/prekey_manager.c
@@ -227,7 +227,7 @@ static otrng_result prekey_message_decode(const char *msg, uint8_t **buffer,
 /*
    The returned value will be owned by the caller
 */
-static char *
+/*@null@*/ static char *
 serialize_dake1(/*@notnull@*/ otrng_prekey_dake1_message_s *dake1) {
   uint8_t *ser = NULL;
   size_t ser_len = 0;
@@ -572,9 +572,9 @@ create_rsig_auth_for_dake3(otrng_client_s *client,
   return ret;
 }
 
-tstatic char *send_dake3(otrng_client_s *client,
-                         otrng_prekey_request_s *request,
-                         const otrng_prekey_dake2_message_s *msg) {
+/*@null@*/ tstatic char *send_dake3(otrng_client_s *client,
+                                    otrng_prekey_request_s *request,
+                                    const otrng_prekey_dake2_message_s *msg) {
   /*
     t = 0x01 || KDF(usage_receiver_client_profile, Alices_Client_Profile, 64) ||
         KDF(usage_receiver_prekey_composite_identity,
@@ -611,9 +611,9 @@ tstatic char *send_dake3(otrng_client_s *client,
   return ret;
 }
 
-static char *process_received_dake2(otrng_client_s *client,
-                                    otrng_prekey_request_s *request,
-                                    const otrng_prekey_dake2_message_s *msg) {
+/*@null@*/ static char *
+process_received_dake2(otrng_client_s *client, otrng_prekey_request_s *request,
+                       const otrng_prekey_dake2_message_s *msg) {
   if (msg->client_instance_tag != otrng_client_get_instance_tag(client)) {
     return NULL;
   }
@@ -648,9 +648,10 @@ void otrng_prekey_check_account_request(otrng_client_s *client) {
   }
 }
 
-static char *receive_dake2(otrng_client_s *client,
-                           otrng_prekey_request_s *request,
-                           const uint8_t *decoded, size_t decoded_len) {
+/*@null@*/ static char *receive_dake2(otrng_client_s *client,
+                                      otrng_prekey_request_s *request,
+                                      const uint8_t *decoded,
+                                      size_t decoded_len) {
   otrng_prekey_dake2_message_s msg;
   char *ret = NULL;
 
@@ -666,7 +667,7 @@ static char *receive_dake2(otrng_client_s *client,
   return ret;
 }
 
-static char *receive_success_or_failure(
+/*@null@*/ static char *receive_success_or_failure(
     otrng_client_s *client, otrng_prekey_request_s *request,
     const uint8_t *decoded, size_t decoded_len, const size_t len,
     const uint8_t usage, const uint8_t error_code,
@@ -708,9 +709,10 @@ static char *receive_success_or_failure(
   return NULL;
 }
 
-static char *receive_success(otrng_client_s *client,
-                             otrng_prekey_request_s *request,
-                             const uint8_t *decoded, size_t decoded_len) {
+/*@null@*/ static char *receive_success(otrng_client_s *client,
+                                        otrng_prekey_request_s *request,
+                                        const uint8_t *decoded,
+                                        size_t decoded_len) {
   assert(client->prekey_manager != NULL);
   return receive_success_or_failure(
       client, request, decoded, decoded_len, OTRNG_PREKEY_SUCCESS_MSG_LEN,
@@ -718,9 +720,10 @@ static char *receive_success(otrng_client_s *client,
       client->prekey_manager->callbacks->success_received);
 }
 
-static char *receive_failure(otrng_client_s *client,
-                             otrng_prekey_request_s *request,
-                             const uint8_t *decoded, size_t decoded_len) {
+/*@null@*/ static char *receive_failure(otrng_client_s *client,
+                                        otrng_prekey_request_s *request,
+                                        const uint8_t *decoded,
+                                        size_t decoded_len) {
   assert(client->prekey_manager != NULL);
   return receive_success_or_failure(
       client, request, decoded, decoded_len, OTRNG_PREKEY_FAILURE_MSG_LEN,
@@ -728,7 +731,7 @@ static char *receive_failure(otrng_client_s *client,
       client->prekey_manager->callbacks->failure_received);
 }
 
-static char *process_received_storage_status(
+/*@null@*/ static char *process_received_storage_status(
     otrng_client_s *client, const otrng_prekey_request_s *request,
     const otrng_prekey_storage_status_message_s *msg) {
   assert(client->prekey_manager != NULL);
@@ -759,10 +762,10 @@ static char *process_received_storage_status(
   return NULL;
 }
 
-static char *receive_storage_status(otrng_client_s *client,
-                                    otrng_prekey_request_s *request,
-                                    const uint8_t *decoded,
-                                    size_t decoded_len) {
+/*@null@*/ static char *receive_storage_status(otrng_client_s *client,
+                                               otrng_prekey_request_s *request,
+                                               const uint8_t *decoded,
+                                               size_t decoded_len) {
   otrng_prekey_storage_status_message_s msg;
   char *ret;
 
@@ -777,9 +780,9 @@ static char *receive_storage_status(otrng_client_s *client,
   return ret;
 }
 
-static char *receive_no_prekey_in_storage(otrng_client_s *client,
-                                          const uint8_t *decoded,
-                                          const size_t decoded_len) {
+/*@null@*/ static char *receive_no_prekey_in_storage(otrng_client_s *client,
+                                                     const uint8_t *decoded,
+                                                     const size_t decoded_len) {
   uint32_t instance_tag = 0;
   size_t read = 0;
   uint8_t *identity_ser = NULL;
@@ -841,9 +844,8 @@ static otrng_result process_received_prekey_ensemble_retrieval(
   return OTRNG_SUCCESS;
 }
 
-static char *receive_prekey_ensemble_retrieval(otrng_client_s *client,
-                                               const uint8_t *decoded,
-                                               const size_t decoded_len) {
+/*@null@*/ static char *receive_prekey_ensemble_retrieval(
+    otrng_client_s *client, const uint8_t *decoded, const size_t decoded_len) {
   otrng_prekey_ensemble_retrieval_message_s msg;
 
   if (!otrng_prekey_ensemble_retrieval_message_deserialize(&msg, decoded,
@@ -863,7 +865,7 @@ static char *receive_prekey_ensemble_retrieval(otrng_client_s *client,
   return NULL;
 }
 
-static otrng_prekey_request_s *
+/*@null@*/ static otrng_prekey_request_s *
 check_current_dake_request(const otrng_client_s *client, const char *from) {
   otrng_prekey_request_s *rfa;
 
@@ -882,10 +884,10 @@ check_current_dake_request(const otrng_client_s *client, const char *from) {
   return NULL;
 }
 
-static char *receive_decoded_message(otrng_client_s *client,
-                                     const uint8_t *decoded,
-                                     const size_t decoded_len,
-                                     /*@notnull@*/ const char *from) {
+/*@null@*/ static char *
+receive_decoded_message(otrng_client_s *client, const uint8_t *decoded,
+                        const size_t decoded_len,
+                        /*@notnull@*/ const char *from) {
   uint8_t msg_type = 0;
   otrng_prekey_request_s *request = NULL;
   char *res;
@@ -938,13 +940,14 @@ static char *receive_decoded_message(otrng_client_s *client,
   case OTRNG_PREKEY_ENSEMBLE_RETRIEVAL_MSG:
     return receive_prekey_ensemble_retrieval(client, decoded, decoded_len);
   default:
-    notify_error(client, OTRNG_PREKEY_CLIENT_MALFORMED_MSG, request->ctx);
+    notify_error(client, OTRNG_PREKEY_CLIENT_MALFORMED_MSG,
+                 request != NULL ? request->ctx : NULL);
   }
 
   return NULL;
 }
 
-tstatic otrng_prekey_server_s *
+/*@null@*/ tstatic otrng_prekey_server_s *
 find_server_for_identity(/*@notnull@*/ otrng_prekey_manager_s *manager,
                          const char *identity) {
   otrng_prekey_server_s *server = NULL;

--- a/src/prekey_profile.c
+++ b/src/prekey_profile.c
@@ -304,7 +304,7 @@ tstatic otrng_result otrng_prekey_profile_sign(
   return OTRNG_SUCCESS;
 }
 
-INTERNAL otrng_prekey_profile_s *
+/*@null@*/ INTERNAL otrng_prekey_profile_s *
 otrng_prekey_profile_build(uint32_t instance_tag,
                            const otrng_keypair_s *longterm_pair) {
   otrng_prekey_profile_s *prekey_profile;

--- a/src/prekey_profile.h
+++ b/src/prekey_profile.h
@@ -55,7 +55,7 @@ INTERNAL void otrng_prekey_profile_free(otrng_prekey_profile_s *dst);
 INTERNAL void otrng_prekey_profile_copy(otrng_prekey_profile_s *dst,
                                         const otrng_prekey_profile_s *src);
 
-INTERNAL otrng_prekey_profile_s *
+/*@null@*/ INTERNAL otrng_prekey_profile_s *
 otrng_prekey_profile_build(uint32_t instance_tag,
                            const otrng_keypair_s *longterm_pair);
 

--- a/src/prekey_proofs.c
+++ b/src/prekey_proofs.c
@@ -204,7 +204,7 @@ INTERNAL otrng_bool otrng_ecdh_proof_verify(ecdh_proof_s *px,
   return otrng_false;
 }
 
-tstatic void *gen_random_data(size_t n, random_generator gen) {
+/*@null@*/ tstatic void *gen_random_data(size_t n, random_generator gen) {
   if (gen == NULL) {
     void *rhash, *rbuf;
     rbuf = gcry_random_bytes_secure(n, GCRY_STRONG_RANDOM);

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -152,8 +152,8 @@ tstatic otrng_result encrypt_data_message(data_message_s *data_msg,
   return OTRNG_SUCCESS;
 }
 
-tstatic data_message_s *generate_data_message(const otrng_s *otr,
-                                              const uint32_t ratchet_id) {
+/*@null@*/ tstatic data_message_s *
+generate_data_message(const otrng_s *otr, const uint32_t ratchet_id) {
   data_message_s *data_msg = otrng_data_message_new();
   if (!data_msg) {
     return NULL;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -174,7 +174,8 @@ INTERNAL size_t otrng_serialize_ring_sig(uint8_t *dst,
   return cursor - dst;
 }
 
-INTERNAL uint8_t *otrng_serialize_old_mac_keys(list_element_s *old_mac_keys) {
+/*@null@*/ INTERNAL uint8_t *
+otrng_serialize_old_mac_keys(list_element_s *old_mac_keys) {
   size_t num_mac_keys = otrng_list_len(old_mac_keys);
   size_t serlen = num_mac_keys * MAC_KEY_BYTES;
   uint8_t *ser_mac_keys;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -96,7 +96,8 @@ INTERNAL size_t otrng_serialize_shared_prekey(
  *
  * @param [old_mac_keys]   The list of old mac keys.
  */
-INTERNAL uint8_t *otrng_serialize_old_mac_keys(list_element_s *old_mac_keys);
+/*@null@*/ INTERNAL uint8_t *
+otrng_serialize_old_mac_keys(list_element_s *old_mac_keys);
 
 INTERNAL size_t otrng_serialize_phi(uint8_t *dst,
                                     const char *shared_session_state,

--- a/src/smp.c
+++ b/src/smp.c
@@ -64,8 +64,8 @@ tstatic void handle_smp_event_cb_v4(const otrng_smp_event event,
   }
 }
 
-tstatic tlv_s *otrng_process_smp(otrng_smp_event *ret, smp_protocol_s *smp,
-                                 const tlv_s *tlv) {
+/*@null@*/ tstatic tlv_s *
+otrng_process_smp(otrng_smp_event *ret, smp_protocol_s *smp, const tlv_s *tlv) {
   otrng_smp_event event = *ret;
   tlv_s *to_send = NULL;
 
@@ -164,7 +164,7 @@ INTERNAL tlv_s *otrng_process_smp_tlv(const tlv_s *tlv, otrng_s *otr) {
   return out;
 }
 
-tstatic tlv_s *
+/*@null@*/ tstatic tlv_s *
 otrng_smp_initiate(const otrng_client_profile_s *initiator_profile,
                    const otrng_client_profile_s *responder_profile,
                    const uint8_t *question, const size_t q_len,
@@ -279,7 +279,7 @@ INTERNAL otrng_result otrng_smp_start(string_p *to_send,
   return OTRNG_ERROR;
 }
 
-tstatic tlv_s *
+/*@null@*/ tstatic tlv_s *
 otrng_smp_provide_secret(otrng_smp_event *event, smp_protocol_s *smp,
                          const otrng_client_profile_s *our_profile,
                          const otrng_client_profile_s *their_client_profile,

--- a/src/smp.h
+++ b/src/smp.h
@@ -32,7 +32,8 @@
 #include "shared.h"
 #include "tlv.h"
 
-INTERNAL tlv_s *otrng_process_smp_tlv(const tlv_s *tlv, otrng_s *otr);
+/*@null@*/ INTERNAL tlv_s *otrng_process_smp_tlv(const tlv_s *tlv,
+                                                 otrng_s *otr);
 
 INTERNAL otrng_result otrng_smp_start(string_p *to_send,
                                       const uint8_t *question,
@@ -47,14 +48,14 @@ API otrng_result otrng_smp_abort(string_p *to_send, otrng_s *otr);
 
 #ifdef OTRNG_SMP_PRIVATE
 
-tstatic tlv_s *
+/*@null@*/ tstatic tlv_s *
 otrng_smp_initiate(const otrng_client_profile_s *initiator_profile,
                    const otrng_client_profile_s *responder_profile,
                    const uint8_t *question, const size_t q_len,
                    const uint8_t *secret, const size_t secretlen, uint8_t *ssid,
                    smp_protocol_s *smp, otrng_s *conversation);
 
-tstatic tlv_s *
+/*@null@*/ tstatic tlv_s *
 otrng_smp_provide_secret(otrng_smp_event *event, smp_protocol_s *smp,
                          const otrng_client_profile_s *our_profile,
                          const otrng_client_profile_s *their_profile,

--- a/src/tlv.c
+++ b/src/tlv.c
@@ -44,7 +44,8 @@ tstatic void set_tlv_type(tlv_s *tlv, uint16_t tlv_type) {
   }
 }
 
-tstatic tlv_s *parse_tlv(const uint8_t *src, size_t len, size_t *read) {
+/*@null@*/ tstatic tlv_s *parse_tlv(const uint8_t *src, size_t len,
+                                    size_t *read) {
   tlv_s *tlv = otrng_tlv_new(OTRNG_TLV_NONE, 0, NULL);
   size_t w = 0;
   uint16_t tlv_type = -1;
@@ -89,7 +90,7 @@ tstatic tlv_s *parse_tlv(const uint8_t *src, size_t len, size_t *read) {
   return tlv;
 }
 
-INTERNAL tlv_list_s *otrng_append_tlv(tlv_list_s *head, tlv_s *tlv) {
+/*@null@*/ INTERNAL tlv_list_s *otrng_append_tlv(tlv_list_s *head, tlv_s *tlv) {
   tlv_list_s *current;
   tlv_list_s *n = otrng_tlv_list_one(tlv);
   if (!n) {
@@ -111,7 +112,8 @@ INTERNAL tlv_list_s *otrng_append_tlv(tlv_list_s *head, tlv_s *tlv) {
   return head;
 }
 
-INTERNAL tlv_list_s *otrng_parse_tlvs(const uint8_t *src, size_t len) {
+/*@null@*/ INTERNAL tlv_list_s *otrng_parse_tlvs(const uint8_t *src,
+                                                 size_t len) {
   tlv_list_s *ret = NULL, *tmp = NULL;
   while (len > 0) {
     size_t read = 0;
@@ -152,8 +154,8 @@ INTERNAL void otrng_tlv_list_free(tlv_list_s *head) {
   }
 }
 
-INTERNAL tlv_s *otrng_tlv_new(const uint16_t type, const uint16_t len,
-                              const uint8_t *data) {
+/*@null@*/ INTERNAL tlv_s *
+otrng_tlv_new(const uint16_t type, const uint16_t len, const uint8_t *data) {
   tlv_s *tlv = otrng_xmalloc_z(sizeof(tlv_s));
 
   tlv->type = type;
@@ -172,11 +174,11 @@ INTERNAL tlv_s *otrng_tlv_new(const uint16_t type, const uint16_t len,
   return tlv;
 }
 
-INTERNAL tlv_s *otrng_tlv_disconnected_new(void) {
+/*@null@*/ INTERNAL tlv_s *otrng_tlv_disconnected_new(void) {
   return otrng_tlv_new(OTRNG_TLV_DISCONNECTED, 0, NULL);
 }
 
-INTERNAL tlv_s *otrng_tlv_padding_new(size_t len) {
+/*@null@*/ INTERNAL tlv_s *otrng_tlv_padding_new(size_t len) {
   uint8_t *data = otrng_xmalloc_z(len);
   tlv_s *tlv;
 
@@ -186,7 +188,7 @@ INTERNAL tlv_s *otrng_tlv_padding_new(size_t len) {
   return tlv;
 }
 
-INTERNAL tlv_list_s *otrng_tlv_list_one(tlv_s *tlv) {
+/*@null@*/ INTERNAL tlv_list_s *otrng_tlv_list_one(tlv_s *tlv) {
   tlv_list_s *tlvs;
   if (!tlv) {
     return NULL;

--- a/src/tlv.h
+++ b/src/tlv.h
@@ -94,7 +94,7 @@ INTERNAL void otrng_tlv_list_free(tlv_list_s *tlvs);
  *    responsibility to free it after use.
  *    returns NULL if something goes wrong, or if [tlv] is NULL.
  **/
-INTERNAL tlv_list_s *otrng_tlv_list_one(tlv_s *tlv);
+/*@null@*/ INTERNAL tlv_list_s *otrng_tlv_list_one(tlv_s *tlv);
 
 /**
  * @brief Returns a newly created disconnected TLV
@@ -103,7 +103,7 @@ INTERNAL tlv_list_s *otrng_tlv_list_one(tlv_s *tlv);
  *    responsibility to free it after use.
  *    returns NULL if something goes wrong.
  **/
-INTERNAL tlv_s *otrng_tlv_disconnected_new(void);
+/*@null@*/ INTERNAL tlv_s *otrng_tlv_disconnected_new(void);
 
 /**
  * @brief Tries to extract as many TLVs as possible in the memory region from
@@ -116,7 +116,8 @@ INTERNAL tlv_s *otrng_tlv_disconnected_new(void);
  *    responsibility to free it after use.
  *    returns NULL if no TLVs can be found.
  **/
-INTERNAL tlv_list_s *otrng_parse_tlvs(const uint8_t *src, size_t len);
+/*@null@*/ INTERNAL tlv_list_s *otrng_parse_tlvs(const uint8_t *src,
+                                                 size_t len);
 
 /**
  * @brief creates a new TLV from the given data.
@@ -132,8 +133,9 @@ INTERNAL tlv_list_s *otrng_parse_tlvs(const uint8_t *src, size_t len);
  *         returns NULL if something goes wrong, if [data] is NULL when [len]
            is > 0.
  **/
-INTERNAL tlv_s *otrng_tlv_new(const uint16_t type, const uint16_t len,
-                              /*@null@*/ const uint8_t *data);
+/*@null@*/ INTERNAL tlv_s *otrng_tlv_new(const uint16_t type,
+                                         const uint16_t len,
+                                         /*@null@*/ const uint8_t *data);
 
 /**
  * @brief appends the given TLV to the list of TLVs
@@ -146,9 +148,10 @@ INTERNAL tlv_s *otrng_tlv_new(const uint16_t type, const uint16_t len,
  *         It is the callers responsibility to free it after use.
  *         Returns NULL if something goes wrong, or if [tlv] is NULL
  **/
-INTERNAL tlv_list_s *otrng_append_tlv(/*@null@*/ tlv_list_s *tlvs, tlv_s *tlv);
+/*@null@*/ INTERNAL tlv_list_s *otrng_append_tlv(/*@null@*/ tlv_list_s *tlvs,
+                                                 tlv_s *tlv);
 
-INTERNAL tlv_s *otrng_tlv_padding_new(size_t len);
+/*@null@*/ INTERNAL tlv_s *otrng_tlv_padding_new(size_t len);
 
 INTERNAL void otrng_tlv_free(tlv_s *tlv);
 

--- a/src/v3.c
+++ b/src/v3.c
@@ -342,8 +342,8 @@ tstatic void op_otr_error_message_free(void *opdata, const char *err_msg) {
  * function is not provided by the application then the default prefix,
  * "[resent]", will be used.
  * */
-tstatic const char *op_resent_message_prefix(void *opdata,
-                                             ConnContext *context) {
+/*@null@*/ tstatic const char *op_resent_message_prefix(void *opdata,
+                                                        ConnContext *context) {
   (void)opdata;
   (void)context;
   return NULL;


### PR DESCRIPTION
This is related to Issue #119.

Splint `nullret` rule refers to a function that returns a possibly `null` pointer, but is not declared using `/*@null@*/` annotation of result. 

This PR add `/*@null@*/` annotation to the return value declaration of some functions.