### PR TITLE
Fix snprintf max size error

### DIFF
--- a/src/fingerprint.c
+++ b/src/fingerprint.c
@@ -38,7 +38,7 @@ API otrng_result otrng_fingerprint_hash_to_human(char *human,
 
   for (word = 0; word < 14; ++word) {
     for (byte = 0; byte < 4; ++byte) {
-      if (snprintf(p, OTRNG_FPRINT_HUMAN_LEN, "%02X",
+      if (snprintf(p, 3, "%02X",
                    (unsigned int)hash[word * 4 + byte]) < 0) {
         return OTRNG_ERROR;
       }


### PR DESCRIPTION
Quick and simple fix for #205 

I have verified that the tests go through on my machine.

@claucece On a related note: there are no checks in this function to verify that `hash` and `human` are of the required length. Perhaps this is somehow implied elsewhere throughout the lib? I haven't taken the time to go through everything well enough to understand where they come from and what guarantees exist that the user can't make those mistakes. Or if this is even an important function. This is just my drive-by coding, you of course know better :)