### PR TITLE
Remove redundant wrapper functions for otrng_bool

### DIFF
--- a/src/client_callbacks.c
+++ b/src/client_callbacks.c
@@ -24,7 +24,7 @@
 
 INTERNAL int
 otrng_client_callbacks_ensure_needed_exist(const otrng_client_callbacks_s *cb) {
-  return otrng_bool_is_true(
+  return (
       cb->create_privkey_v3 != NULL && cb->create_privkey_v4 != NULL &&
       cb->create_forging_key != NULL && cb->create_client_profile != NULL &&
       cb->store_expired_client_profile != NULL &&

--- a/src/client_profile.c
+++ b/src/client_profile.c
@@ -545,8 +545,8 @@ client_profile_verify_signature(const otrng_client_profile_s *client_profile) {
 
   memset(pubkey, 0, ED448_POINT_BYTES);
 
-  if (otrng_bool_is_true(otrng_is_empty_array(client_profile->signature,
-                                              ED448_SIGNATURE_BYTES))) {
+  if (otrng_is_empty_array(client_profile->signature,
+			   ED448_SIGNATURE_BYTES)) {
     return otrng_false;
   }
 

--- a/src/ed448.c
+++ b/src/ed448.c
@@ -191,8 +191,7 @@ static otrng_bool otrng_ecdh_valid_secret(uint8_t *shared_secret,
     return otrng_false;
   }
 
-  if (otrng_bool_is_true(
-          otrng_is_empty_array(shared_secret, ED448_POINT_BYTES))) {
+  if (otrng_is_empty_array(shared_secret, ED448_POINT_BYTES)) {
     return otrng_false;
   }
 

--- a/src/error.h
+++ b/src/error.h
@@ -37,7 +37,9 @@
 
 // needed for comparing with GOLDILOCKS_TRUE
 typedef uint8_t
-    otrng_bool; /* "Boolean" type, will be set to all-zero or all-one */
+    otrng_bool; /* "Boolean" type, will be set to 0 or 1. Compatible
+		   with C native boolean logic so conditionals on
+		   otrng_bool works as expected) */
 
 static const otrng_bool otrng_true = 1;
 static const otrng_bool otrng_false = 0;
@@ -57,20 +59,6 @@ typedef enum {
 
 /*@unused@*/ static inline otrng_bool otrng_result_to_bool(otrng_result v) {
   if (v == OTRNG_SUCCESS) {
-    return otrng_true;
-  }
-  return otrng_false;
-}
-
-/*@unused@*/ static inline int otrng_bool_is_true(otrng_bool v) {
-  if (v == OTRNG_SUCCESS) {
-    return 1;
-  }
-  return 0;
-}
-
-/*@unused@*/ static inline otrng_bool c_bool_to_otrng_bool(int v) {
-  if (v) {
     return otrng_true;
   }
   return otrng_false;

--- a/src/key_management.c
+++ b/src/key_management.c
@@ -967,8 +967,7 @@ tstatic otrng_result store_enc_keys(
     return OTRNG_SUCCESS;
   }
 
-  if (!otrng_bool_is_true(otrng_is_empty_array(tmp_receiving_ratchet->chain_r,
-                                               CHAIN_KEY_BYTES))) {
+  if (!otrng_is_empty_array(tmp_receiving_ratchet->chain_r, CHAIN_KEY_BYTES)) {
     while (tmp_receiving_ratchet->k < until) {
       if (!shake_256_kdf1(enc_key, ENC_KEY_BYTES, usage_message_key,
                           tmp_receiving_ratchet->chain_r, CHAIN_KEY_BYTES)) {

--- a/src/prekey_profile.c
+++ b/src/prekey_profile.c
@@ -349,8 +349,7 @@ otrng_prekey_profile_verify_signature(const otrng_prekey_profile_s *profile,
   uint8_t pubkey[ED448_POINT_BYTES];
   otrng_bool valid;
 
-  if (otrng_bool_is_true(
-          otrng_is_empty_array(profile->signature, ED448_SIGNATURE_BYTES))) {
+  if (otrng_is_empty_array(profile->signature, ED448_SIGNATURE_BYTES)) {
     return otrng_false;
   }
 


### PR DESCRIPTION
The otrng_bool is compatible with the C standard boolean logic so the
`otrng_bool_is_true` wrapper isn't needed. The conversion function
`c_bool_to_otrng_bool` is unused across the code base and can also be
safely removed.

The intent of this change is to declutter the code a bit. For
`otrng_bool_is_true` to serve as an abstraction, one would have to
apply it consistently wherever otrng_bool is examined. That would
clutter the code for little practical value though so it seems better
to just remove it.

It's possible of course that I misunderstand the purpose of
`otrng_bool`, and perhaps there are future plans conflicting with this
change. If so I apologise for the noise! :)